### PR TITLE
Add parameter for `path()` method instead of using concatenation for …

### DIFF
--- a/app/Project.php
+++ b/app/Project.php
@@ -18,11 +18,18 @@ class Project extends Model
     /**
      *  The path to the project.
      *
+     * @param string $add The additional path for the Project url
      * @return string
      */
-    public function path()
+    public function path($add = null)
     {
-        return "/projects/{$this->id}";
+        $path = "/projects/{$this->id}";
+
+        if ($add) {
+            $path .= "/$add";
+        }
+
+        return $path;
     }
 
     /**

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -21,7 +21,7 @@
                     alt="{{ $project->owner->name }}'s avatar"
                     class="rounded-full w-8 mr-2">
 
-                <a href="{{ $project->path().'/edit' }}" class="button ml-4">Edit Project</a>
+                <a href="{{ $project->path('edit') }}" class="button ml-4">Edit Project</a>
             </div>
         </div>
     </header>
@@ -48,7 +48,7 @@
                     @endforeach
 
                     <div class="card mb-3">
-                        <form action="{{ $project->path() . '/tasks' }}" method="POST">
+                        <form action="{{ $project->path('tasks') }}" method="POST">
                             @csrf
 
                             <input placeholder="Add a new task..." class="w-full" name="body">

--- a/tests/Feature/InvitationsTest.php
+++ b/tests/Feature/InvitationsTest.php
@@ -19,7 +19,7 @@ class InvitationsTest extends TestCase
 
         $assertInvitationForbidden = function () use ($user, $project) {
             $this->actingAs($user)
-                ->post($project->path() . '/invitations')
+                ->post($project->path('invitations'))
                 ->assertStatus(403);
         };
 
@@ -38,7 +38,7 @@ class InvitationsTest extends TestCase
         $userToInvite = factory(User::class)->create();
 
         $this->actingAs($project->owner)
-            ->post($project->path() . '/invitations', [
+            ->post($project->path('invitations'), [
                 'email' => $userToInvite->email
             ])
             ->assertRedirect($project->path());
@@ -52,7 +52,7 @@ class InvitationsTest extends TestCase
         $project = ProjectFactory::create();
 
         $this->actingAs($project->owner)
-            ->post($project->path() . '/invitations', [
+            ->post($project->path('invitations'), [
                 'email' => 'notauser@example.com'
             ])
             ->assertSessionHasErrors([

--- a/tests/Feature/ProjectTasksTest.php
+++ b/tests/Feature/ProjectTasksTest.php
@@ -16,7 +16,7 @@ class ProjectTasksTest extends TestCase
     {
         $project = factory('App\Project')->create();
 
-        $this->post($project->path() . '/tasks')->assertRedirect('login');
+        $this->post($project->path('tasks'))->assertRedirect('login');
     }
 
     /** @test */
@@ -26,7 +26,7 @@ class ProjectTasksTest extends TestCase
 
         $project = factory('App\Project')->create();
 
-        $this->post($project->path() . '/tasks', ['body' => 'Test task'])
+        $this->post($project->path('tasks'), ['body' => 'Test task'])
             ->assertStatus(403);
 
         $this->assertDatabaseMissing('tasks', ['body' => 'Test task']);
@@ -51,7 +51,7 @@ class ProjectTasksTest extends TestCase
         $project = ProjectFactory::create();
 
         $this->actingAs($project->owner)
-             ->post($project->path() . '/tasks', ['body' => 'Test task']);
+             ->post($project->path('tasks'), ['body' => 'Test task']);
 
         $this->get($project->path())
             ->assertSee('Test task');
@@ -121,7 +121,7 @@ class ProjectTasksTest extends TestCase
         $attributes = factory('App\Task')->raw(['body' => '']);
 
         $this->actingAs($project->owner)
-             ->post($project->path() . '/tasks', $attributes)
+             ->post($project->path('tasks'), $attributes)
             ->assertSessionHasErrors('body');
     }
 }


### PR DESCRIPTION
…paths inline.

While I would typically use the `route()` helper function, I can see the merit in this approach also. I think this is cleaner than concatenating strings for urls inline; let the function handle that.