### PR TITLE
Set default user_id on RecordsActivity to authenticated user. Fixes #5

### DIFF
--- a/app/RecordsActivity.php
+++ b/app/RecordsActivity.php
@@ -62,7 +62,7 @@ trait RecordsActivity
     public function recordActivity($description)
     {
         $this->activity()->create([
-            'user_id' => ($this->project ?? $this)->owner->id,
+            'user_id' => auth()->id() ?: ($this->project ?? $this)->owner->id,
             'description' => $description,
             'changes' => $this->activityChanges(),
             'project_id' => class_basename($this) === 'Project' ? $this->id : $this->project_id

--- a/tests/Feature/TriggerActivityTest.php
+++ b/tests/Feature/TriggerActivityTest.php
@@ -3,9 +3,10 @@
 namespace Tests\Feature;
 
 use App\Task;
+use App\User;
+use Tests\TestCase;
 use Facades\Tests\Setup\ProjectFactory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
 class TriggerActivityTest extends TestCase
 {
@@ -60,6 +61,22 @@ class TriggerActivityTest extends TestCase
             $this->assertEquals('created_task', $activity->description);
             $this->assertInstanceOf(Task::class, $activity->subject);
             $this->assertEquals('Some task', $activity->subject->body);
+        });
+    }
+
+    /** @test */
+    function creating_a_new_task_as_a_collaborator()
+    {
+        $owner = factory(User::class)->create();
+
+        tap(ProjectFactory::ownedBy($owner)->create(), function($project) {
+            $collaborator = $this->signIn();
+
+            $project->invite($collaborator);
+
+            $project->addTask("Some Task");
+
+            $this->assertEquals($project->activity->last()->user_id, $collaborator->id);
         });
     }
 


### PR DESCRIPTION
As mentioned in #5 , the `user_id` recorded in the activity feed will incorrectly attribute activity performed by collaborators to the project owner.